### PR TITLE
Workaround for gcc 4.x stdlib defect

### DIFF
--- a/rdmini/small_map.h
+++ b/rdmini/small_map.h
@@ -104,7 +104,12 @@ public:
     }
 
     iterator erase(const_iterator pos) {
+/* work asround for defect in libstdc++ for gcc version < 5 */
+#if defined(__GNUC__) && __GNUC__ < 5
+        return v.erase(v.begin()+std::distance(cbegin(),pos));
+#else
         return v.erase(pos);
+#endif
     }
 
     size_type erase(const key_type &key) {


### PR DESCRIPTION
Vector erase method should have signature
````
std::vector<T>::erase(const_iterator)
````
rather than
````
std::vector<T>::erase(iterator)
````
in C++11, but this is not fixed in gcc until version 5.